### PR TITLE
Update hooks.php

### DIFF
--- a/modules/addons/userengage/hooks.php
+++ b/modules/addons/userengage/hooks.php
@@ -21,7 +21,7 @@ function userengage_ClientAreaFooterOutput($vars) {
 	$params = array();
 	if (isset($vars['clientsdetails']))
 	{
-		$params[] = ['key' => 'name', 'value' => $vars['clientdetails']['firstname'] . $vars['clientdetails']['lastname'] ];
+		$params[] = ['key' => 'name', 'value' => $vars['clientsdetails']['firstname'] . ' ' . $vars['clientsdetails']['lastname'] ];
 		$keys = array(
 			'email' => 'email'
 		);


### PR DESCRIPTION
The clients name was not pulling through I noticed a typo in the property it was set to `$vars['clientdetails']['firstname']` it should be `$vars['clientsdetails']['firstname']` (added S in clientS). Also added a space between first and last name.
